### PR TITLE
Update bootstrap.js

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -2954,9 +2954,9 @@ function changeUI(window) {
         + "px 0px";
     else if (isMac)
       newStatus.style.margin = "-"
-        + (window.getComputedStyle(gURLBar).paddingTop.replace("px", '')*1 + 2)
+        + (window.getComputedStyle(gURLBar).paddingTop.replace("px", '')*1 + 3)
         + "px 0px -"
-        + (window.getComputedStyle(gURLBar).paddingBottom.replace("px", '')*1 + 3)
+        + (window.getComputedStyle(gURLBar).paddingBottom.replace("px", '')*1 + 2)
         + "px 0px";
     origInput.parentNode.insertBefore(newStatusCon, origInput.nextSibling);
     function animateToggleEnhancedURLBar(hiding) {


### PR DESCRIPTION
Fix for the location bar size so that it is compatible with Firefox Mac.
It avoids the location bar to increase its height when it is either in normal state or acting as status bar to show an hovered link's address.
